### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Next, you and your partner should both add the class repository as an upstream g
 
 ```bash
 $ git remote add upstream https://github.com/msu/csci-468-spring2021.git
-$ git pull upstream master
-$ git push origin master
+$ git pull upstream main
+$ git push origin main
 ```
 This will synchronize your private repository with the class repository.
 
 When you want to get an update from the public class repository you can run this command:
 
 ```
-$ git pull upstream master
+$ git pull upstream main
 ```
 
 ## CatScript


### PR DESCRIPTION
As I was adding the class repo as an upstream repo, I noticed that the 'master' branch was actually titled 'main'. Apparently, GitHub recently decided to dump the term 'master' for a more neutral term. The changes in this README replace the instances of anything having to do with an upstream 'master' branch with the correct 'main' branch title. Also, I quickly want to piggy-back off of what Teyler said in his pull request; you are an awesome professor. I am thoroughly looking forward to taking this class. Thank you!