### PR TITLE
Extend CatScriptTokenizerTest.basicSyntax() to check token stringValue.

### DIFF
--- a/src/test/java/edu/montana/csci/csci468/tokenizer/CatScriptTokenizerTest.java
+++ b/src/test/java/edu/montana/csci/csci468/tokenizer/CatScriptTokenizerTest.java
@@ -71,6 +71,15 @@ public class CatScriptTokenizerTest extends CatscriptTestBase {
                 EQUAL, EQUAL_EQUAL,
                 GREATER, GREATER_EQUAL,
                 LESS, LESS_EQUAL, EOF);
+        assertTokensAre("( ) { } [ ] : , . - + / * != = == > >= < <=",
+                "(", ")",
+                "{", "}",
+                "[", "]",
+                ":", ",", ".", "-", "+", "/", "*",
+                "!=",
+                "=", "==",
+                ">", ">=",
+                "<", "<=", "<EOF>");
     }
 
     @Test


### PR DESCRIPTION
Hey Carson!

I did so much copy-paste-tweak'ing for the syntax scanning that I figured a little more testing was in order -- just in case I forgot to fix a stringValue after pasting.

No idea if you want this, but here it is anyway! Thanks for all the project infrastructure!